### PR TITLE
Create/Edit Persons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,46 +1,88 @@
 import React from "react";
 import GridView from "./GridView";
 import Household from "./Household";
-import { Person } from "./types";
+import { PersonData, CovidEvent, CovidEventName } from "./types";
+import moment, { Moment } from "moment";
 
 interface Props {}
 
 interface State {
-  members: Person[];
+  members: PersonData[];
+  editing: boolean;
 }
 
 export default class App extends React.Component<Props, State> {
   state: State = {
     members: [
       {
-        name: `Person 1`,
-        covidEvents: []
+        name: `Alice`,
+        covidEvents: [
+          {
+            name: CovidEventName.LastCloseContact,
+            date: moment("8-25-2020", "MM-DD-YYYY")
+          }
+          /*
+            {
+                name: CovidEventName.SymptomsStart,
+                date: moment("8-28-2020","MM-DD-YYYY")
+            },
+            {
+                name: CovidEventName.PositiveTest,
+                date: moment("8-29-2020","MM-DD-YYYY")
+            }
+            */
+        ],
+        isNewPerson: false,
+        editing: false
+      },
+      {
+        name: `Bob`,
+        covidEvents: [
+          {
+            name: CovidEventName.LastCloseContact,
+            date: moment("8-28-2020", "MM-DD-YYYY")
+          }
+        ],
+        isNewPerson: false,
+        editing: false
       }
-    ]
+    ],
+    editing: false
   };
 
-  handleNewPerson = () => {
-    let updatedmembers: Person[] = JSON.parse(
+  handleAddNewPerson = () => {
+    let updatedMembers: PersonData[] = JSON.parse(
       JSON.stringify(this.state.members)
     );
-    updatedmembers.push({
+    updatedMembers.push({
       name: `Person ${this.state.members.length + 1}`,
-      covidEvents: []
+      covidEvents: [],
+      isNewPerson: true,
+      editing: true
     });
     this.setState({
-      members: updatedmembers
+      members: updatedMembers,
+      editing: true
     });
   };
 
-  handleNewEvent = () => {};
+  handlePersonChanges = (updatedPersonData: PersonData, index: number) => {
+    let updatedMembers: PersonData[] = JSON.parse(
+      JSON.stringify(this.state.members)
+    );
+    updatedMembers[index] = updatedPersonData;
+    this.setState({
+      members: updatedMembers
+    });
+  };
 
   handleRemovePerson = (index: number) => {
-    let updatedmembers: Person[] = JSON.parse(
+    let updatedMembers: PersonData[] = JSON.parse(
       JSON.stringify(this.state.members)
     );
-    updatedmembers.splice(index, 1);
+    updatedMembers.splice(index, 1);
     this.setState({
-      members: updatedmembers
+      members: updatedMembers
     });
   };
 
@@ -49,18 +91,19 @@ export default class App extends React.Component<Props, State> {
       <main className="f7 f5-l">
         <h1>Covid Quarantine Qualculator</h1>
         <div className="flex-l">
-          <div className="w-30-l bw1 bg-light-gray pt5 pb5 pb7-l ph4 pr5-l">
+          <div className="w-70-l bw1 bg-light-gray pt5 pb5 pb7-l ph4 pr5-l">
             <div className="center mr0-l ml-auto-l">
               <Household
                 members={this.state.members}
-                handleNewPerson={this.handleNewPerson}
+                handleAddNewPerson={this.handleAddNewPerson}
+                handlePersonChanges={this.handlePersonChanges}
                 handleRemovePerson={this.handleRemovePerson}
-                handleNewEvent={this.handleNewEvent}
+                editing={this.state.editing}
               />
             </div>
           </div>
-          <div className="w-70-l pt2 pt5-l pb2 ph2 ph6-l">
-            <GridView />
+          <div className="w-30-l pt2 pt5-l pb2 ph2 pr4-l">
+            <GridView members={this.state.members} />
           </div>
         </div>
       </main>

--- a/src/GridView.tsx
+++ b/src/GridView.tsx
@@ -1,12 +1,30 @@
 import React from "react";
 import FullCalendar from "@fullcalendar/react";
 import dayGridPlugin from "@fullcalendar/daygrid";
+import { computeHouseHoldQuarantinePeriod } from "./calculator";
+import { PersonData, CalculationResult } from "./types";
+import moment, { Moment } from "moment";
 
-export default class GridView extends React.Component {
+interface Props {
+  members: PersonData[];
+}
+export default class GridView extends React.Component<Props> {
   render() {
     return (
-      <div className="">
-        <FullCalendar plugins={[dayGridPlugin]} initialView="dayGridMonth" />
+      <div>
+        <div className="pb3">(calendar will go here.)</div>
+
+        {computeHouseHoldQuarantinePeriod(this.props.members).map(
+          (result: CalculationResult) => {
+            return (
+              <div className="p32">
+                {result.person.name} {" quarantined until: "}{" "}
+                {moment(result.date).format("MM/DD/YYYY")}
+              </div>
+            );
+          }
+        )}
+        {/*<FullCalendar plugins={[dayGridPlugin]} initialView="dayGridMonth" />*/}
       </div>
     );
   }

--- a/src/Household.tsx
+++ b/src/Household.tsx
@@ -1,60 +1,68 @@
 import React from "react";
-import { Person, CovidEventName } from "./types";
+import { PersonData, CovidEventName, CovidEvent } from "./types";
+import Person from "./Person";
 
 interface Props {
-  members: Person[];
-  handleNewEvent: Function;
-  handleNewPerson: Function;
+  members: PersonData[];
+  handleAddNewPerson: Function;
+  handlePersonChanges: Function;
   handleRemovePerson: Function;
+  editing: boolean;
+}
+interface State {
+  editing: boolean;
 }
 
-export default class Household extends React.Component<Props> {
+export default class Household extends React.Component<Props, State> {
+  state = {
+    editing: this.props.editing
+  };
+
   render() {
     return (
       <div className="">
         <div className="f3">Household</div>
         <div className="pa2">
-          {this.props.members.map((person: Person, i) => {
+          {this.props.members.map((personData: PersonData, i) => {
             return (
-              <div className="f4">
-                {person.name}
-
-                {this.props.members.length > 1 && (
-                  <button
-                    onClick={() => {
-                      this.props.handleRemovePerson();
-                    }}
-                  >
-                    <span className="visually-hidden">Remove Person</span>
-                    <i
-                      aria-hidden="true"
-                      className="pl2 fas fa-times-circle gray"
-                    ></i>
-                  </button>
-                )}
-
-                <div className="pl3">
-                  {Object.values(CovidEventName).map(
-                    (name: CovidEventName, i) => {
-                      return (
-                        <div className="f5">
-                          <button>{"+ " + name}</button>
-                        </div>
-                      );
-                    }
-                  )}
-                </div>
-              </div>
+              <Person
+                personIndex={i}
+                personData={personData}
+                submitPersonData={(
+                  updatedPersonData: PersonData,
+                  index: number
+                ) => {
+                  this.setState({ editing: false });
+                  this.props.handlePersonChanges(updatedPersonData, index);
+                }}
+                handleRemovePerson={() => {
+                  this.props.handleRemovePerson(i);
+                  this.setState({ editing: false });
+                }}
+                handleBeginEdit={() => {
+                  this.setState({ editing: true });
+                }}
+                handleCancelEdit={() => {
+                  if (personData.isNewPerson) {
+                    this.props.handleRemovePerson(i);
+                  }
+                  this.setState({ editing: false });
+                }}
+                editingHousehold={this.state.editing}
+              />
             );
           })}
-          <button
-            className="pa2 f5 fw6"
-            onClick={() => {
-              this.props.handleNewPerson();
-            }}
-          >
-            Add Person
-          </button>
+          {!this.state.editing && (
+            <button
+              className="pa2 f5 fw6"
+              onClick={() => {
+                this.props.handleAddNewPerson();
+                this.setState({ editing: true });
+              }}
+            >
+              Add Person
+            </button>
+          )}
         </div>
       </div>
     );

--- a/src/Person.tsx
+++ b/src/Person.tsx
@@ -1,0 +1,190 @@
+import React from "react";
+import { PersonData, CovidEvent, CovidEventName } from "./types";
+import moment, { Moment } from "moment";
+
+interface Props {
+  personIndex: number;
+  personData: PersonData;
+  submitPersonData: Function;
+  handleCancelEdit: Function;
+  handleBeginEdit: Function;
+  handleRemovePerson: Function;
+  editingHousehold: boolean;
+}
+
+interface State {
+  name: string;
+  lastCloseContactDate: string;
+  positiveTestDate: string;
+  firstSymptomsDate: string;
+  symptomsResolved: string;
+  exposuresInHousehold: any;
+  editing: boolean;
+}
+
+export default class Person extends React.Component<Props, State> {
+  state = {
+    name: this.props.personData.name,
+    lastCloseContactDate: "",
+    positiveTestDate: "",
+    firstSymptomsDate: "",
+    symptomsResolved: "",
+    exposuresInHousehold: null,
+    editing: this.props.personData.editing
+  };
+
+  handleChange = (e: React.BaseSyntheticEvent) => {
+    this.setState<any>({
+      [e.target.name]: e.target.value
+    });
+  };
+  handleSubmitClick = () => {
+    let covidEvents: CovidEvent[] = [];
+    if (this.state.lastCloseContactDate) {
+      covidEvents.push({
+        name: CovidEventName.LastCloseContact,
+        date: moment(this.state.lastCloseContactDate, "MM-DD-YYYY")
+      });
+    }
+    if (this.state.positiveTestDate) {
+      covidEvents.push({
+        name: CovidEventName.PositiveTest,
+        date: moment(this.state.positiveTestDate, "MM-DD-YYYY")
+      });
+    }
+    if (this.state.firstSymptomsDate) {
+      covidEvents.push({
+        name: CovidEventName.SymptomsStart,
+        date: moment(this.state.firstSymptomsDate, "MM-DD-YYYY")
+      });
+    }
+    const personData = {
+      name: this.state.name,
+      covidEvents: covidEvents,
+      isNewPerson: false,
+      editing: false
+    };
+    this.props.submitPersonData(personData, this.props.personIndex);
+    this.setState({ editing: false });
+  };
+
+  render() {
+    return (
+      <div className="f4 ba bw1 pa2">
+        {this.props.personData.name}{" "}
+        {!this.props.editingHousehold && (
+          <button
+            onClick={() => {
+              this.props.handleBeginEdit();
+              this.setState({ editing: true });
+            }}
+          >
+            <span className="visually-hidden">Edit Person</span>
+            <span aria-hidden="true" className="pl2 f5 fas fa-pen"></span>
+          </button>
+        )}
+        {this.state.editing ? (
+          <div className="pa3">
+            <button
+              onClick={() => {
+                this.props.handleCancelEdit();
+                this.setState({ editing: false });
+              }}
+            >
+              <span className="visually-hidden">Cancel</span>
+              {this.props.personData.isNewPerson ? "Cancel Add" : "Cancel Edit"}
+              <i
+                aria-hidden="true"
+                className="pl2 fas fa-times-circle gray"
+              ></i>
+            </button>
+            {!this.props.personData.isNewPerson && (
+              <button
+                onClick={() => {
+                  this.props.handleRemovePerson();
+                }}
+              >
+                <span className="visually-hidden">Remove Person</span>
+                Remove Person
+                <i
+                  aria-hidden="true"
+                  className="pl2 fas fa-times-circle gray"
+                ></i>
+              </button>
+            )}
+            <div>
+              Name:
+              <input
+                value={this.state.name}
+                name="name"
+                id={`${this.props.personIndex}-${this.state.name}`}
+                type="text"
+                onChange={this.handleChange}
+              />
+            </div>
+
+            <div>
+              When is the last date you have been exposed to someone covid
+              positive outside the household?
+              <input
+                value={this.state.lastCloseContactDate}
+                name="lastCloseContactDate"
+                id={`${this.props.personIndex}-${this.state.lastCloseContactDate}`}
+                type="text"
+                /*
+                Accessibility Stuff TODO.
+                required={this.props.required}
+                aria-invalid={this.state.hasInput}
+                aria-describedby={
+                  this.props.required && this.state.hasInput
+                    ? this.props.errorMessage
+                    : undefined
+                }
+                */
+                onChange={this.handleChange}
+              />
+            </div>
+            <div>
+              If you have received a positive test result, what date did you
+              take the test?
+              <input
+                value={this.state.positiveTestDate}
+                name="positiveTestDate"
+                id={`${this.props.personIndex}-${this.state.positiveTestDate}`}
+                type="text"
+                onChange={this.handleChange}
+              />
+            </div>
+            <div>
+              If you are or were showing symptoms, when did your symptoms begin?
+              <input
+                value={this.state.firstSymptomsDate}
+                name="firstSymptomsDate"
+                id={`${this.props.personIndex}-${this.state.firstSymptomsDate}`}
+                type="text"
+                onChange={this.handleChange}
+              />
+            </div>
+            <button
+              className="fw5 pa2 bg-green white bg-animate hover-bg-light-green"
+              onClick={this.handleSubmitClick}
+            >
+              Submit Person Information
+            </button>
+          </div>
+        ) : (
+          <div className="pl3">
+            {console.log(this.props.personData.covidEvents)}
+            {this.props.personData.covidEvents.map((event: CovidEvent, i) => {
+              return (
+                <div className="f5">
+                  {event.name} {": "} {moment(event.date).format("MM/DD/YYYY")}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/src/calculator.test.ts
+++ b/src/calculator.test.ts
@@ -1,9 +1,10 @@
 import { computeIsolationPeriod } from "./calculator";
-import { Person } from "./types";
+import { PersonData } from "./types";
 
-const kent: Person = {
+const kent: PersonData = {
   name: "Kent",
-  covidEvents: []
+  covidEvents: [],
+  isNewPerson: false
 };
 
 test("Empty", () => {

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -1,11 +1,11 @@
-import { CalculationResult, CovidEventName, Person } from "./types";
+import { CalculationResult, CovidEventName, PersonData } from "./types";
 import * as _ from "lodash";
 import moment, { Moment } from "moment";
 
-function computeHouseHoldQuarantinePeriod(
-  household: Person[]
+export function computeHouseHoldQuarantinePeriod(
+  household: PersonData[]
 ): CalculationResult[] {
-  return household.map((person: Person, i: number) => {
+  return household.map((person: PersonData, i: number) => {
     const isolationPeriod = computeIsolationPeriod(person);
     if (isolationPeriod) {
       return { person: person, date: isolationPeriod };
@@ -16,7 +16,7 @@ function computeHouseHoldQuarantinePeriod(
   });
 }
 
-export function computeIsolationPeriod(person: Person): Moment | undefined {
+export function computeIsolationPeriod(person: PersonData): Moment | undefined {
   const illnessOnset = _.chain(person.covidEvents)
     .filter(event => {
       return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,10 @@
-import { Moment } from "moment";
+import moment, { Moment } from "moment";
 
-export interface Person {
+export interface PersonData {
   name: string;
   covidEvents: CovidEvent[];
+  isNewPerson: boolean;
+  editing: boolean;
 }
 
 export interface CovidEvent {
@@ -19,6 +21,6 @@ export enum CovidEventName {
 }
 
 export interface CalculationResult {
-  person: Person;
+  person: PersonData;
   date: Moment;
 }


### PR DESCRIPTION
Create, edit, and remove Persons with some Event types: 

Exposure, showing symptoms, and positive test.

Date fields don't get validated, but are all mm/dd/yyyy format.

It shows the result from the Calculator!

Renamed Person to PersonData again, because I made a new Person Component.

What it doesn't do:

* Can't provide a Negative Test date.

* When editing, we don't pre-populate date text fields for events that already exist. This would be nice though.

* The Calendar Grid is gone. Can do that from scratch after we have the full text-based input / output features.

* Doesn't support the in-household pairwise exposure questions.

BUG! If you add a NewSymptoms or Positive Test event, and then do another "Add Person", there will be a
type error on Moment, because Moment is confusing.
