### PR TITLE
Begin In-house exposure interface

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,12 @@ import { PersonData, CovidEventName } from "./types";
 import { parseISO } from "date-fns";
 
 export default function App() {
-  const initialMembers : PersonData[] = [
+  const initialMembers: PersonData[] = [
     {
       name: `Alice`,
       covidEvents: {
-        LastCloseContact: parseISO("2020-08-25")
+        LastCloseContact: parseISO("2020-08-25"),
+        InHouseExposure: {}
       },
       isNewPerson: false,
       editing: false
@@ -17,7 +18,8 @@ export default function App() {
     {
       name: `Bob`,
       covidEvents: {
-        LastCloseContact: parseISO("2020-08-28")
+        LastCloseContact: parseISO("2020-08-28"),
+        InHouseExposure: {}
       },
       isNewPerson: false,
       editing: false
@@ -30,7 +32,9 @@ export default function App() {
   const handleAddNewPerson = () => {
     const newPerson = {
       name: `Person ${members.length + 1}`,
-      covidEvents: {},
+      covidEvents: {
+        InHouseExposure: {}
+      },
       isNewPerson: true,
       editing: true
     };
@@ -39,6 +43,12 @@ export default function App() {
   };
 
   const handlePersonChanges = (updatedPersonData: PersonData, i: number) => {
+    for (const otherPerson of members) {
+      if (updatedPersonData.covidEvents.InHouseExposure[otherPerson.name]) {
+        otherPerson.covidEvents.InHouseExposure[updatedPersonData.name] =
+          updatedPersonData.covidEvents.InHouseExposure[otherPerson.name];
+      }
+    }
     setMembers(members => [
       ...members.slice(0, i),
       updatedPersonData,
@@ -55,20 +65,30 @@ export default function App() {
     <main className="mt5 f7 f5-m f4-l bg-white ba b-black">
       <h1 className="ph3">Covid Quarantine Calculator</h1>
       <div className="flex-l">
-        <div className={"bw1 pb5 pb7-l pr5-l " + (editing ? "w-70-l" : "w-50-l")} >
+        <div
+          className={"bw1 pb5 pb7-l pr5-l " + (editing ? "w-70-l" : "w-50-l")}
+        >
           <div className="center mr0-l ml-auto-l">
             <Household
               members={members}
               handleAddNewPerson={handleAddNewPerson}
               handlePersonChanges={handlePersonChanges}
               handleRemovePerson={handleRemovePerson}
-              handleBeginEdit={() => {setEditing(true);}}
-              handleCancelEdit={() => {setEditing(false);}}
+              handleBeginEdit={() => {
+                setEditing(true);
+              }}
+              handleCancelEdit={() => {
+                setEditing(false);
+              }}
               editing={editing}
             />
           </div>
         </div>
-        <div className={"pt2 pt5-l pb2 ph2 pr4-l " + (editing ? "w-30-l" : "w-50-l")}>
+        <div
+          className={
+            "pt2 pt5-l pb2 ph2 pr4-l " + (editing ? "w-30-l" : "w-50-l")
+          }
+        >
           <GridView members={members} />
         </div>
       </div>

--- a/src/Household.tsx
+++ b/src/Household.tsx
@@ -13,10 +13,13 @@ interface Props {
 }
 
 export default function Household(props: Props) {
-
   return (
     <div className="">
-      <div className="f3 pa3"> <span className="bg-light-green pv2 ph2 mr2 f7"> (icon) </span> Household</div>
+      <div className="f3 pa3">
+        {" "}
+        <span className="bg-light-green pv2 ph2 mr2 f7"> (icon) </span>{" "}
+        Household
+      </div>
       <div className="pa2">
         {props.members.map((personData: PersonData, i) => {
           return (

--- a/src/Person.tsx
+++ b/src/Person.tsx
@@ -15,17 +15,35 @@ interface Props {
 export default function Person(props: Props) {
   const personData = props.householdPersonData[props.personIndex];
 
-  const lastCloseContactDate = personData.covidEvents.LastCloseContact ? format(personData.covidEvents.LastCloseContact, "M/dd/yyyy") : "";
-  const positiveTestDate = personData.covidEvents.PositiveTest ? format(personData.covidEvents.PositiveTest, "M/dd/yyyy") : "";
-  const firstSymptomsDate = personData.covidEvents.SymptomsStart ? format(personData.covidEvents.SymptomsStart, "M/dd/yyyy") : "";
-  const symptomsResolved = personData.covidEvents.SymptomsEnd ? format(personData.covidEvents.SymptomsEnd, "M/dd/yyyy") : "";
+  const lastCloseContactDate = personData.covidEvents.LastCloseContact
+    ? format(personData.covidEvents.LastCloseContact, "M/dd/yyyy")
+    : "";
+  const positiveTestDate = personData.covidEvents.PositiveTest
+    ? format(personData.covidEvents.PositiveTest, "M/dd/yyyy")
+    : "";
+  const firstSymptomsDate = personData.covidEvents.SymptomsStart
+    ? format(personData.covidEvents.SymptomsStart, "M/dd/yyyy")
+    : "";
+  const symptomsResolved = personData.covidEvents.SymptomsEnd
+    ? format(personData.covidEvents.SymptomsEnd, "M/dd/yyyy")
+    : "";
+
+  let initialInHouseExposureFields: { [key: string]: string } = {};
+  {
+    Object.entries(personData.covidEvents.InHouseExposure).map(
+      (entry: [string, Date]) => {
+        initialInHouseExposureFields[entry[0]] = format(entry[1], "MM/dd/yyyy");
+      }
+    );
+  }
+
   const initialState = {
     name: personData.name,
     lastCloseContactDate,
     positiveTestDate,
     firstSymptomsDate,
     symptomsResolved,
-    exposuresInHousehold: null
+    inHouseExposureFields: initialInHouseExposureFields
   };
   const [state, setState] = useState(initialState);
   const [editing, setEditing] = useState(props.editingHousehold);
@@ -38,17 +56,37 @@ export default function Person(props: Props) {
   };
 
   const handleSubmitClick = () => {
-    let covidEvents: CovidEvents = {};
+    let covidEvents: CovidEvents = { InHouseExposure: {} };
     if (state.lastCloseContactDate) {
-      covidEvents.LastCloseContact = parse(state.lastCloseContactDate, "M/dd/yyyy", new Date());
+      covidEvents.LastCloseContact = parse(
+        state.lastCloseContactDate,
+        "M/dd/yyyy",
+        new Date()
+      );
     }
     if (state.positiveTestDate) {
-      covidEvents.PositiveTest = parse(state.positiveTestDate, "M/dd/yyyy", new Date());
+      covidEvents.PositiveTest = parse(
+        state.positiveTestDate,
+        "M/dd/yyyy",
+        new Date()
+      );
     }
     if (state.firstSymptomsDate) {
-      covidEvents.SymptomsStart = parse(state.firstSymptomsDate, "M/dd/yyyy", new Date());
+      covidEvents.SymptomsStart = parse(
+        state.firstSymptomsDate,
+        "M/dd/yyyy",
+        new Date()
+      );
     }
-
+    let inHouseExposures: { [name: string]: Date } = {};
+    {
+      Object.entries(state.inHouseExposureFields).map(
+        (entry: [string, string]) => {
+          inHouseExposures[entry[0]] = parse(entry[1], "M/dd/yyyy", new Date());
+        }
+      );
+    }
+    covidEvents.InHouseExposure = inHouseExposures;
     const personData = {
       name: state.name,
       covidEvents: covidEvents,
@@ -59,49 +97,67 @@ export default function Person(props: Props) {
     props.submitPersonData(personData, props.personIndex);
   };
 
+  const inHouseExposureNames = props.householdPersonData
+    .filter((otherPerson: PersonData) => {
+      const personContagious = Boolean(
+        state.positiveTestDate || state.firstSymptomsDate
+      );
+      const otherPersonContagious = Boolean(
+        otherPerson.covidEvents.PositiveTest ||
+          otherPerson.covidEvents.SymptomsStart
+      );
+      return (
+        state.name !== otherPerson.name &&
+        personContagious !== otherPersonContagious
+      );
+    })
+    .map((person, index) => {
+      return person.name;
+    });
+
   return (
-    <div className={"f4 ma2 br4 pv2 bg-light-blue"}  >
+    <div className={"f4 ma2 br4 pv2 bg-light-blue"}>
       <div className="pl5 fw5">
-      {personData.name}{" "}
-      {!props.editingHousehold && (
-        <button
-          onClick={() => {
-            props.handleBeginEdit();
-            setEditing(true);
-          }}
-        >
-          <span className="visually-hidden">Edit Person</span>
-          <span aria-hidden="true" className="pl2 f5 fas fa-pen"></span>
-        </button>
-      )}
+        {personData.name}{" "}
+        {!props.editingHousehold && (
+          <button
+            onClick={() => {
+              props.handleBeginEdit();
+              setEditing(true);
+            }}
+          >
+            <span className="visually-hidden">Edit Person</span>
+            <span aria-hidden="true" className="pl2 f5 fas fa-pen"></span>
+          </button>
+        )}
       </div>
-      <div className = {(editing ? "" : "pl5")}>
-      {editing ? (
-        <div className="pa3">
+      <div className={editing ? "" : "pl5"}>
+        {editing ? (
+          <div className="pa3">
+            <div className="pa2">
+              Name:
+              <input
+                className="w4"
+                value={state.name}
+                name="name"
+                id={`${props.personIndex}-${state.name}`}
+                type="text"
+                onChange={handleChange}
+              />
+            </div>
 
-          <div>
-            Name:
-            <input
-              value={state.name}
-              name="name"
-              id={`${props.personIndex}-${state.name}`}
-              type="text"
-              onChange={handleChange}
-            />
-          </div>
-
-          <div className="pa2">
-
-            <p className="pb2">
-            When is the last date you have been exposed to someone covid
-            positive outside the household?
-            </p>
-            <input
-              value={state.lastCloseContactDate}
-              name="lastCloseContactDate"
-              id={`${props.personIndex}-${state.lastCloseContactDate}`}
-              type="text"
-              /*
+            <div className="pa2">
+              <p className="pb2">
+                When is the last date you have been exposed to someone covid
+                positive outside the household?
+              </p>
+              <input
+                className="ml3 w4"
+                value={state.lastCloseContactDate}
+                name="lastCloseContactDate"
+                id={`${props.personIndex}-${state.lastCloseContactDate}`}
+                type="text"
+                /*
               Accessibility Stuff TODO.
               required={this.props.required}
               aria-invalid={this.state.hasInput}
@@ -111,78 +167,124 @@ export default function Person(props: Props) {
                   : undefined
               }
               */
-              onChange={handleChange}
-            />
-          </div>
-          <div>
-            If you have received a positive test result, what date did you take
-            the test?
-            <input
-              value={state.positiveTestDate}
-              name="positiveTestDate"
-              id={`${props.personIndex}-${state.positiveTestDate}`}
-              type="text"
-              onChange={handleChange}
-            />
-          </div>
-          <div>
-            If you are or were showing symptoms, when did your symptoms begin?
-            <input
-              value={state.firstSymptomsDate}
-              name="firstSymptomsDate"
-              id={`${props.personIndex}-${state.firstSymptomsDate}`}
-              type="text"
-              onChange={handleChange}
-            />
-          </div>
-          <button
-            className="fw5 pa2 bg-green white bg-animate hover-bg-dark-green"
-            onClick={handleSubmitClick}
-          >
-            {personData.isNewPerson ? "Submit" : "Update"}
-          </button>
-          <button
-            className="ma2 fw5 pa2 bg-yellow white bg-animate hover-bg-light-yellow"
-            onClick={() => {
-              props.handleCancelEdit();
-              setEditing(false);
-            }}
-          >
-            <span className="visually-hidden">Cancel</span>
-            {personData.isNewPerson ? "Cancel Add" : "Cancel Edit"}
-            <i aria-hidden="true" className="pl2 fas fa-times-circle gray"></i>
-          </button>
-          {!personData.isNewPerson && (
+                onChange={handleChange}
+              />
+            </div>
+            <div className="pa2">
+              <p className="pb2">
+                If you have received a positive test result, what date did you
+                take the test?
+              </p>
+              <input
+                className="ml3 w4"
+                value={state.positiveTestDate}
+                name="positiveTestDate"
+                id={`${props.personIndex}-${state.positiveTestDate}`}
+                type="text"
+                onChange={handleChange}
+              />
+            </div>
+            <div className="pa2">
+              <p className="pb2">
+                If you are or were showing symptoms, when did your symptoms
+                begin?
+              </p>
+              <input
+                className="ml3 w4"
+                value={state.firstSymptomsDate}
+                name="firstSymptomsDate"
+                id={`${props.personIndex}-${state.firstSymptomsDate}`}
+                type="text"
+                onChange={handleChange}
+              />
+            </div>
+            {inHouseExposureNames.map((personName, index) => {
+              return (
+                <div className="pa2">
+                  <p className="pb2">
+                    When was your last exposure to {personName}?
+                  </p>
+                  <input
+                    className="ml3 w4"
+                    value={state.inHouseExposureFields[personName] || ""}
+                    name={`crossExposure-${index}`}
+                    id={`crossExposure-${props.personIndex}-${index}`}
+                    type="text"
+                    onChange={(e: React.BaseSyntheticEvent) => {
+                      let updatedInHouseExposureFields = JSON.parse(
+                        JSON.stringify(state.inHouseExposureFields)
+                      );
+                      updatedInHouseExposureFields[personName] = e.target.value;
+                      setState({
+                        ...state,
+                        inHouseExposureFields: updatedInHouseExposureFields
+                      });
+                    }}
+                  />
+                </div>
+              );
+            })}
             <button
-              className="ma2 fw5 pa2 bg-washed-red bg-animate hover-bg-light-red"
+              className="fw5 pa2 bg-green white bg-animate hover-bg-dark-green"
+              onClick={handleSubmitClick}
+            >
+              {personData.isNewPerson ? "Submit" : "Update"}
+            </button>
+            <button
+              className="ma2 fw5 pa2 bg-yellow white bg-animate hover-bg-light-yellow"
               onClick={() => {
-
-                props.handleRemovePerson();
+                props.handleCancelEdit();
                 setEditing(false);
-
               }}
             >
-              <span className="visually-hidden">Remove</span>
-              Remove
+              <span className="visually-hidden">Cancel</span>
+              {personData.isNewPerson ? "Cancel Add" : "Cancel Edit"}
               <i
                 aria-hidden="true"
                 className="pl2 fas fa-times-circle gray"
               ></i>
             </button>
-          )}
-        </div>
-      ) : (
-        <div className="pl3">
-          {Object.entries(personData.covidEvents).map((entry: [string, Date] , _: number) => {
-            return (
-              <div className="f5">
-                {entry[0]} {": "} {format(entry[1], "MM/dd/yyyy")}
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
+            {!personData.isNewPerson && (
+              <button
+                className="ma2 fw5 pa2 bg-washed-red bg-animate hover-bg-light-red"
+                onClick={() => {
+                  props.handleRemovePerson();
+                  setEditing(false);
+                }}
+              >
+                <span className="visually-hidden">Remove</span>
+                Remove
+                <i
+                  aria-hidden="true"
+                  className="pl2 fas fa-times-circle gray"
+                ></i>
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="pl3">
+            {Object.entries(personData.covidEvents)
+              .filter((entry: [string, any]) => entry[0] !== "InHouseExposure")
+              .map((entry: [string, Date], _: number) => {
+                return (
+                  <div className="f5">
+                    {entry[0]} {": "} {format(entry[1], "MM/dd/yyyy")}
+                  </div>
+                );
+              })}
+            {Object.entries(personData.covidEvents.InHouseExposure).map(
+              (entry: [string, Date], _: number) => {
+                return (
+                  <div className="f5">
+                    Exposed to {entry[0]} {": "}{" "}
+                    {format(entry[1], "MM/dd/yyyy")}
+                  </div>
+                );
+              }
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,7 @@ export interface CovidEvents {
   SymptomsEnd?: Date;
   PositiveTest?: Date;
   NegativeTest?: Date;
-  InHouseExposure?: InHouseExposureEvents;
+  InHouseExposure: InHouseExposureEvents;
 }
 
 export interface InHouseExposureEvents {


### PR DESCRIPTION
Asks for in-house exposures for any opposite pairs of contagious/non-contagios persons.

When Person A has an exposure to Person B, appends the symmetric exposure of person B to Person A.

Doesn't change the calculator.

Behavior is kind of buggy.

Because of how the useState hook works differently from React States, I'm having trouble getting field states to stay matched with actual underlying data (try doing an edit, delete a field, hit cancel, and hit edit again. The field ought to be re-populated, but it is not.)

Also the symmetric exposure information is not deleted if you remove one person's exposure event.

Stopping here with it unfinshed, sorry :(( .