### PR TITLE
Abstracted the Date questions somewhat.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,7 +122,7 @@ export default function App() {
 
   return (
     <main className="mt5 f7 f5-m f4-l bg-white ba b-black">
-      <h1 className="ph3">Covid Quarantine Calculator</h1>
+      <h1 className="ph3 f3">Covid Quarantine Calculator</h1>
       <div className="flex-l">
         <div
           className={"bw1 pb5 pb7-l pr5-l " + (editing ? "w-70-l" : "w-50-l")}
@@ -143,6 +143,12 @@ export default function App() {
                 setEditing(false);
               }}
               editing={editing}
+              handleFocusDateField={(fieldName: string) => {
+                console.log("In-app focused date field is ", fieldName);
+              }}
+              handleUnfocusDateField={(fieldName: string) => {
+                console.log("In-app unfocused date field is ", fieldName);
+              }}
             />
           </div>
         </div>

--- a/src/DateQuestion.tsx
+++ b/src/DateQuestion.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { parse, format } from "date-fns";
+
+interface Props {
+  personIndex: number;
+  questionText: string;
+  questionFieldText: string;
+  questionFieldName: string;
+  onChange: Function;
+  onFocus: Function;
+  onUnfocus: Function;
+}
+
+export default function DateQuestion(props: Props) {
+  const [questionFieldText, setQuestionFieldText] = useState(
+    props.questionFieldText
+  );
+  const twoDigitYearPattern = new RegExp(
+    "^([0-9][0-9]?/[0-9][0-9]?/)([0-9][0-9])$"
+  );
+  const dayMonthPattern = new RegExp("^[0-9][0-9]?/[0-9][0-9]?$");
+
+  const handleTextChange = (e: React.BaseSyntheticEvent) => {
+    setQuestionFieldText(e.target.value);
+    props.onChange(e);
+  };
+
+  const handleUnfocus = () => {
+    console.log(
+      "unfocus",
+      props.questionFieldName,
+      ", must autocomplete year and unhighlight cal"
+    );
+
+    let fixedDate = questionFieldText;
+    const twoDigitYearMatch = twoDigitYearPattern.exec(fixedDate);
+    if (twoDigitYearMatch) {
+      fixedDate = fixedDate.slice(0, -2) + "20" + fixedDate.slice(-2);
+    }
+    const dayMonthMatch = dayMonthPattern.exec(fixedDate);
+    if (dayMonthMatch) {
+      fixedDate = fixedDate + "/2020";
+    }
+    console.log("fixed date is: ", fixedDate);
+    setQuestionFieldText(fixedDate);
+    props.onChange({
+      target: { name: props.questionFieldName, value: fixedDate }
+    });
+    props.onUnfocus(props.questionFieldName);
+  };
+
+  const handleFocus = () => {
+    console.log("focus", props.questionFieldName, ", must highlight cal");
+    props.onFocus(props.questionFieldName);
+  };
+
+  return (
+    <div className="pa3">
+      <div className="pa2">
+        {props.questionText} <span className="f6 fw3">mm/dd/yyyy</span>
+      </div>
+      <input
+        className="w4 ml2"
+        value={questionFieldText}
+        name={props.questionFieldName}
+        id={`${props.personIndex}-${props.questionText}`}
+        type="text"
+        onChange={handleTextChange}
+        onFocus={handleFocus}
+        onBlur={handleUnfocus}
+      />
+    </div>
+  );
+}

--- a/src/Household.tsx
+++ b/src/Household.tsx
@@ -12,6 +12,8 @@ interface Props {
   handleCancelEdit: Function;
   handlePersonChanges: Function;
   handleRemovePerson: Function;
+  handleFocusDateField: Function;
+  handleUnfocusDateField: Function;
   editing: boolean;
 }
 
@@ -54,9 +56,12 @@ export default function Household(props: Props) {
                   props.handleCancelEdit();
                 }}
                 editingHousehold={props.editing}
+                handleFocusDateField={props.handleFocusDateField}
+                handleUnfocusDateField={props.handleUnfocusDateField}
               />
             );
           })}
+
         {!props.editing && (
           <button
             className="pa2 f5 fw6"

--- a/src/MultipleChoiceQuestion.tsx
+++ b/src/MultipleChoiceQuestion.tsx
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import { parse, format } from "date-fns";
+
+interface Props {
+  personIndex: number;
+  questionText: string;
+  options: string[];
+  selected: number;
+  onChange: Function;
+}
+
+export default function MultipleChoiceQuestion(props: Props) {
+  return (
+    <fieldset className="relative">
+      <legend className="mb2">{props.questionText}</legend>
+      <div className="radio">
+        {Object.keys(props.options).map((answer: string, index: number) => {
+          return (
+            <div className="dib" key={index}>
+              <input
+                type="radio"
+                //name={answer}
+                id={`${props.personIndex}-${props.questionText}-${index}`}
+                value={index}
+                onChange={() => {
+                  props.onChange(index);
+                }}
+                checked={index === props.selected}
+              />
+              <label
+                htmlFor={`${props.personIndex}-${props.questionText}-${index}`}
+              >
+                {props.options[index]}
+              </label>
+            </div>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,11 +16,14 @@ export enum CovidEventName {
 }
 
 export interface CovidEvents {
+  [key: string]: Date;
+  /*
   LastCloseContact?: Date;
   SymptomsStart?: Date;
   SymptomsEnd?: Date;
   PositiveTest?: Date;
   NegativeTest?: Date;
+  */
 }
 
 export interface InHouseExposureEvent {


### PR DESCRIPTION
Using strings as CovidEvent keys, to make the cookie-cutter Date questions possible. Calculator appears to be unaffected.

Plus basic date text completion if the user adds no year or a 2-digit year.

Added onFocus and onBlur triggers to be used later, when we click a date to select. Has some console garbage. 

No input validation yet, still :((