### PR TITLE
Change InHouseExposureEvent to take person IDs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,8 +37,8 @@ export default function App() {
     const newExposureEvents = members.get().map((person: PersonData) => {
       if (isContagious(person)) {
         return {
-          contagiousPerson: person,
-          quarantinedPerson: newPerson,
+          contagiousPerson: person.id,
+          quarantinedPerson: newPerson.id,
           exposed: true,
           ongoing: false,
           date: ""

--- a/src/InHouseExposureQuestions.tsx
+++ b/src/InHouseExposureQuestions.tsx
@@ -17,8 +17,8 @@ export default function InHouseExposureQuestions(props: Props) {
           (eventState: State<InHouseExposureEvent>) => {
             const event = eventState.get();
             return (
-              event.quarantinedPerson.name === otherPerson.name ||
-              event.contagiousPerson.name === otherPerson.name
+              event.quarantinedPerson === otherPerson.id ||
+              event.contagiousPerson === otherPerson.id
             );
           }
         );

--- a/src/Person.tsx
+++ b/src/Person.tsx
@@ -20,6 +20,7 @@ interface Props {
 
 export default function Person(props: Props) {
   const person = props.personState.get();
+  const members = props.membersState.get();
   const covidEventsState = props.personState.covidEvents;
   const editing = props.editingState.get();
   const relevantInHouseExposureEventsState: State<
@@ -28,8 +29,8 @@ export default function Person(props: Props) {
     (eventState: State<InHouseExposureEvent>) => {
       const event: InHouseExposureEvent = eventState.get();
       return (
-        event.contagiousPerson.id === person.id ||
-        event.quarantinedPerson.id === person.id
+        event.contagiousPerson === person.id ||
+        event.quarantinedPerson === person.id
       );
     }
   );
@@ -113,13 +114,12 @@ export default function Person(props: Props) {
 
   function setContagiousState(contagious: boolean) {
     relevantInHouseExposureEventsState.map(e => e.set(none)); // Remove all current exposures
-    const members = props.membersState.get();
     const newExposureEvents = members.map((otherPerson: PersonData) => {
       const otherContagious = isContagious(otherPerson);
       if (person !== otherPerson && contagious !== otherContagious) {
         return {
-          contagiousPerson: contagious ? person : otherPerson,
-          quarantinedPerson: contagious ? otherPerson : person,
+          contagiousPerson: contagious ? person.id : otherPerson.id,
+          quarantinedPerson: contagious ? otherPerson.id : person.id,
           exposed: true,
           ongoing: false,
           date: ""
@@ -240,10 +240,16 @@ export default function Person(props: Props) {
               {Object.values(relevantInHouseExposureEvents).map(
                 (event: InHouseExposureEvent) => {
                   if (event.exposed) {
+                    const quarantinedPersonName = members.find(
+                      member => member.id === event.quarantinedPerson
+                    )?.name;
+                    const contagiousPersonName = members.find(
+                      member => member.id === event.contagiousPerson
+                    )?.name;
                     return (
                       <div className="f5">
-                        {event.quarantinedPerson.name} exposed to{" "}
-                        {event.contagiousPerson.name} at {event.date}
+                        {quarantinedPersonName} exposed to{" "}
+                        {contagiousPersonName} at {event.date}
                       </div>
                     );
                   }

--- a/src/calculator.test.ts
+++ b/src/calculator.test.ts
@@ -14,7 +14,7 @@ const empty: PersonData = {
 };
 
 const jordan: PersonData = {
-  id: 0,
+  id: 1,
   name: "Jordan",
   covidEvents: {
     SymptomsStart: "01/01/2020"
@@ -24,7 +24,7 @@ const jordan: PersonData = {
 };
 
 const kent: PersonData = {
-  id: 0,
+  id: 2,
   name: "Foo",
   covidEvents: {
     PositiveTest: "01/01/2020"
@@ -34,7 +34,7 @@ const kent: PersonData = {
 };
 
 const personA: PersonData = {
-  id: 0,
+  id: 3,
   name: "Person A",
   covidEvents: {
     PositiveTest: "01/01/2020",
@@ -45,7 +45,7 @@ const personA: PersonData = {
 };
 
 const personB: PersonData = {
-  id: 0,
+  id: 4,
   name: "Person B",
   covidEvents: {
     PositiveTest: "01/01/2020",
@@ -57,7 +57,7 @@ const personB: PersonData = {
 };
 
 const personC: PersonData = {
-  id: 0,
+  id: 5,
   name: "Person C",
   covidEvents: {
     PositiveTest: "01/01/2020",
@@ -96,8 +96,8 @@ test("Isolation Period makes use of symptoms end", () => {
 
 test("Household calculation for one infected and one caretaker", () => {
   const inHouseExposureEvent = {
-    contagiousPerson: personA,
-    quarantinedPerson: empty,
+    contagiousPerson: personA.id,
+    quarantinedPerson: empty.id,
     exposed: true,
     ongoing: true,
     date: ""
@@ -112,8 +112,8 @@ test("Household calculation for one infected and one caretaker", () => {
 
 test("Household calculation for one infected and isolated peer", () => {
   const inHouseExposureEvent = {
-    contagiousPerson: personA,
-    quarantinedPerson: empty,
+    contagiousPerson: personA.id,
+    quarantinedPerson: empty.id,
     exposed: true,
     ongoing: false,
     date: "1/5/2020"

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -32,13 +32,13 @@ export function computeHouseHoldQuarantinePeriod(
     calculation => {
       const person = calculation.person;
       const exposureEvents = inHouseExposureEvents.filter(
-        event => event.quarantinedPerson === person && event.exposed
+        event => event.quarantinedPerson === person.id && event.exposed
       );
       const exposureDates = exposureEvents.map(event => {
         if (event.ongoing) {
           return (
             infected.find(
-              calculation => calculation.person === event.contagiousPerson
+              calculation => calculation.person.id === event.contagiousPerson
             )?.endDate || new Date()
           );
         } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,8 @@ export interface CovidEvents {
 }
 
 export interface InHouseExposureEvent {
-  contagiousPerson: PersonData;
-  quarantinedPerson: PersonData;
+  contagiousPerson: number;
+  quarantinedPerson: number;
   exposed: boolean;
   ongoing: boolean;
   date: string;


### PR DESCRIPTION
This allows us to remove InHouseExposureEvents without removing the underlying Person.