### PR TITLE
Fix "Error: HOOKSTATE-107" when selecting a date

### DIFF
--- a/src/GridView.tsx
+++ b/src/GridView.tsx
@@ -47,9 +47,14 @@ export default function GridView(props: Props) {
             events={computeEvents(members, props.inHouseExposureEvents)}
             dateClick={(info: any) => {
               if (props.editing >= 0 && selectingDateField) {
-                props.membersState[props.editing - 1].covidEvents[
-                  selectingDateField
-                ].set(format(info.date, "MM/dd/yyyy"));
+                const index = props.membersState.findIndex(
+                  memberState => memberState.get().id === props.editing
+                );
+                if (index) {
+                  props.membersState[index].covidEvents[selectingDateField].set(
+                    format(info.date, "MM/dd/yyyy")
+                  );
+                }
               }
             }}
           />


### PR DESCRIPTION
Previously the code was written to assume that `props.editing` was the index of the member. It is now fixed so that it finds the person with an id of `props.editing`.