### PR TITLE
Remove index truthy check before indexing into memberState

### DIFF
--- a/src/GridView.tsx
+++ b/src/GridView.tsx
@@ -50,11 +50,9 @@ export default function GridView(props: Props) {
                 const index = props.membersState.findIndex(
                   memberState => memberState.get().id === props.editing
                 );
-                if (index) {
-                  props.membersState[index].covidEvents[editingDateField].set(
-                    format(info.date, "MM/dd/yyyy")
-                  );
-                }
+                props.membersState[index].covidEvents[editingDateField].set(
+                  format(info.date, "MM/dd/yyyy")
+                );
               }
             }}
           />


### PR DESCRIPTION
The if check fails if index === 0. We do not need to check for a possible -1 from findIndex as it will never happen.