### PR TITLE
Allow in house exposure dates to be selected from calendar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,7 +37,9 @@ export default function App() {
   const inHouseExposureEvents = useState<InHouseExposureEvent[]>([]);
   const editing = useState<number | undefined>(undefined);
   const id = useState(members.length + 1);
-  const editingDateField = useState<CovidEventName | undefined>(undefined);
+  const eventSetterState = useState<((date: string) => void) | undefined>(
+    undefined
+  );
 
   function addNewPerson() {
     const currentId = id.get();
@@ -95,7 +97,7 @@ export default function App() {
             membersState={members}
             inHouseExposureEventsState={inHouseExposureEvents}
             editingState={editing}
-            editingDateFieldState={editingDateField}
+            eventSetterState={eventSetterState}
             addNewPerson={addNewPerson}
           />
         </div>
@@ -103,7 +105,7 @@ export default function App() {
           <GridView
             membersState={members}
             editing={editing.get()}
-            editingDateFieldState={editingDateField}
+            eventSetterState={eventSetterState}
             inHouseExposureEvents={inHouseExposureEvents.get()}
           />
         </div>

--- a/src/GridView.tsx
+++ b/src/GridView.tsx
@@ -5,24 +5,19 @@ import interactionPlugin, { DateClickArg } from "@fullcalendar/interaction";
 import { computeHouseHoldQuarantinePeriod } from "./calculator";
 import { colors } from "./types";
 
-import {
-  PersonData,
-  CalculationResult,
-  InHouseExposureEvent,
-  CovidEventName
-} from "./types";
+import { PersonData, CalculationResult, InHouseExposureEvent } from "./types";
 import { format } from "date-fns";
 import { State } from "@hookstate/core/dist";
 interface Props {
   membersState: State<PersonData[]>;
   inHouseExposureEvents: InHouseExposureEvent[];
   editing: number | undefined;
-  editingDateFieldState: State<CovidEventName | undefined>;
+  eventSetterState: State<((date: string) => void) | undefined>;
 }
 
 export default function GridView(props: Props) {
   const members = props.membersState.get();
-  const editingDateField = props.editingDateFieldState.get();
+  const eventSetter = props.eventSetterState.get();
   function computeEvents(
     members: PersonData[],
     inHouseExposureEvents: InHouseExposureEvent[]
@@ -44,19 +39,14 @@ export default function GridView(props: Props) {
   return (
     <div className={"p-3"}>
       {
-        <div className={editingDateField ? "ba bw2 b--light-yellow" : ""}>
+        <div className={eventSetter ? "ba bw2 b--light-yellow" : ""}>
           <FullCalendar
             plugins={[dayGridPlugin, interactionPlugin]}
             initialView="dayGridMonth"
             events={computeEvents(members, props.inHouseExposureEvents)}
             dateClick={(info: DateClickArg) => {
-              if (props.editing && editingDateField) {
-                const index = props.membersState.findIndex(
-                  memberState => memberState.get().id === props.editing
-                );
-                props.membersState[index].covidEvents[editingDateField].set(
-                  format(info.date, "MM/dd/yyyy")
-                );
+              if (eventSetter) {
+                eventSetter(format(info.date, "MM/dd/yyyy"));
               }
             }}
           />

--- a/src/Household.tsx
+++ b/src/Household.tsx
@@ -1,10 +1,5 @@
 import React from "react";
-import {
-  CalculationResult,
-  CovidEventName,
-  InHouseExposureEvent,
-  PersonData
-} from "./types";
+import { CalculationResult, InHouseExposureEvent, PersonData } from "./types";
 import Person from "./Person";
 import { State } from "@hookstate/core";
 import { computeHouseHoldQuarantinePeriod } from "./calculator";
@@ -15,7 +10,7 @@ interface Props {
   membersState: State<PersonData[]>;
   inHouseExposureEventsState: State<InHouseExposureEvent[]>;
   editingState: State<number | undefined>;
-  editingDateFieldState: State<CovidEventName | undefined>;
+  eventSetterState: State<((date: string) => void) | undefined>;
 }
 
 export default function Household(props: Props) {
@@ -40,7 +35,7 @@ export default function Household(props: Props) {
               membersState={props.membersState}
               inHouseExposureEventsState={props.inHouseExposureEventsState}
               editingState={props.editingState}
-              editingDateFieldState={props.editingDateFieldState}
+              eventSetterState={props.eventSetterState}
             />
           );
         })}

--- a/src/InHouseExposureQuestion.tsx
+++ b/src/InHouseExposureQuestion.tsx
@@ -9,6 +9,7 @@ interface Props {
   index: number;
   otherPerson: PersonData;
   inHouseExposureEventState: State<InHouseExposureEvent>;
+  eventSetterState: State<((date: string) => void) | undefined>;
 }
 
 export default function InHouseExposureQuestion(props: Props) {
@@ -39,8 +40,12 @@ export default function InHouseExposureQuestion(props: Props) {
           onChange={(e: React.BaseSyntheticEvent) =>
             props.inHouseExposureEventState.date.set(e.target.value)
           }
-          onFocus={() => {}}
-          onUnfocus={() => {}}
+          onFocus={() =>
+            props.eventSetterState.set(() => (date: string) => {
+              props.inHouseExposureEventState.date.set(date);
+            })
+          }
+          onUnfocus={() => props.eventSetterState.set(undefined)}
           missing={inHouseExposureEvent.dateMissing}
           invalid={inHouseExposureEvent.dateInvalid}
         />

--- a/src/InHouseExposureQuestions.tsx
+++ b/src/InHouseExposureQuestions.tsx
@@ -7,6 +7,7 @@ interface Props {
   id: number;
   meaningfulInHouseExposures: PersonData[];
   relevantInHouseExposureEventsState: State<InHouseExposureEvent>[];
+  eventSetterState: State<((date: string) => void) | undefined>;
 }
 
 export default function InHouseExposureQuestions(props: Props) {
@@ -31,6 +32,7 @@ export default function InHouseExposureQuestions(props: Props) {
                 index={index}
                 otherPerson={otherPerson}
                 inHouseExposureEventState={inHouseExposureEventState}
+                eventSetterState={props.eventSetterState}
               />
               <hr />
             </>

--- a/src/Person.tsx
+++ b/src/Person.tsx
@@ -18,7 +18,7 @@ interface Props {
   membersState: State<PersonData[]>;
   inHouseExposureEventsState: State<InHouseExposureEvent[]>;
   editingState: State<number | undefined>;
-  editingDateFieldState: State<CovidEventName | undefined>;
+  eventSetterState: State<((date: string) => void) | undefined>;
 }
 
 export default function Person(props: Props) {
@@ -113,8 +113,12 @@ export default function Person(props: Props) {
             questionFieldTextState={covidEventsState[fieldName]}
             questionFieldName={fieldName}
             onChange={handleChange}
-            onFocus={() => props.editingDateFieldState.set(fieldName)}
-            onUnfocus={() => props.editingDateFieldState.set(undefined)}
+            onFocus={() =>
+              props.eventSetterState.set(() => (date: string) =>
+                covidEventsState[fieldName].set(date)
+              )
+            }
+            onUnfocus={() => props.eventSetterState.set(undefined)}
             missing={datesMissing[fieldName].get()}
             invalid={datesInvalid[fieldName].get()}
           />
@@ -152,9 +156,11 @@ export default function Person(props: Props) {
             questionFieldName={CovidEventName.SymptomsStart}
             onChange={handleChange}
             onFocus={() =>
-              props.editingDateFieldState.set(CovidEventName.SymptomsStart)
+              props.eventSetterState.set(() => (date: string) =>
+                covidEventsState[CovidEventName.SymptomsStart].set(date)
+              )
             }
-            onUnfocus={() => props.editingDateFieldState.set(undefined)}
+            onUnfocus={() => props.eventSetterState.set(undefined)}
             missing={datesMissing[CovidEventName.SymptomsStart].get()}
             invalid={datesInvalid[CovidEventName.SymptomsStart].get()}
           />
@@ -301,6 +307,7 @@ export default function Person(props: Props) {
             relevantInHouseExposureEventsState={
               relevantInHouseExposureEventsState
             }
+            eventSetterState={props.eventSetterState}
           />
           <div className={"d-flex justify-content-between align-items-center"}>
             <button


### PR DESCRIPTION
We unify our eventSetterState so that it takes a function that when called by the GridView, it will set the appropriate event state.

Resolves https://github.com/codeforpdx/covid-calendar/issues/53