### PR TITLE
Remove notion of start date

### DIFF
--- a/src/GridView.tsx
+++ b/src/GridView.tsx
@@ -6,7 +6,7 @@ import { computeHouseHoldQuarantinePeriod } from "./calculator";
 import { colors } from "./types";
 
 import { PersonData, CalculationResult, InHouseExposureEvent } from "./types";
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import { State } from "@hookstate/core/dist";
 interface Props {
   membersState: State<PersonData[]>;
@@ -27,7 +27,7 @@ export default function GridView(props: Props) {
         return {
           classNames: ["TODO"],
           title: result.person.name,
-          start: result.startDate,
+          start: parseISO("1970-01-01"),
           end: result.endDate,
           color: colors[result.person.id - (1 % colors.length)],
           textColor: "#000000"

--- a/src/Household.tsx
+++ b/src/Household.tsx
@@ -64,7 +64,7 @@ export default function Household(props: Props) {
           {computeHouseHoldQuarantinePeriod(members, inHouseExposureEvents)
             .sort((r1, r2) => r1.person.id - r2.person.id)
             .map((result: CalculationResult) => {
-              if (isValid(result.startDate) && isValid(result.endDate)) {
+              if (isValid(result.endDate)) {
                 return (
                   <div className="p32">
                     <span className="">
@@ -76,10 +76,7 @@ export default function Household(props: Props) {
                       ></i>
                       {result.person.name + " "}
                     </span>{" "}
-                    {` should ${
-                      result.infected ? "isolate" : "quarantine"
-                    } from `}{" "}
-                    {format(result.startDate, "MM/dd/yyyy")}
+                    should {result.infected ? "isolate" : "quarantine"}
                     {" until "}
                     {result.person.noSymptomsFor24Hours
                       ? format(result.endDate, "MM/dd/yyyy")

--- a/src/calculator.test.ts
+++ b/src/calculator.test.ts
@@ -84,39 +84,30 @@ const personWithOutsideExposure: PersonData = {
 };
 
 test("Empty", () => {
-  const [, endDate] = computeIsolationPeriod(empty);
+  const endDate = computeIsolationPeriod(empty);
   expect(isValid(endDate)).toBe(false);
 });
 
 test("Person with positive symptoms isolates for 10 days", () => {
-  const [startDate, endDate] = computeIsolationPeriod(
-    personWithPositiveSymptoms
-  );
-  expect(startDate).toStrictEqual(parseISO("2020-01-01"));
+  const endDate = computeIsolationPeriod(personWithPositiveSymptoms);
   expect(endDate).toStrictEqual(parseISO("2020-01-11"));
 });
 
 test("Person with positive test isolates for 10 days", () => {
-  const [startDate, endDate] = computeIsolationPeriod(personWithPositiveTest);
-  expect(startDate).toStrictEqual(parseISO("2020-01-01"));
+  const endDate = computeIsolationPeriod(personWithPositiveTest);
   expect(endDate).toStrictEqual(parseISO("2020-01-11"));
 });
 
 test("Person starts isolating on earlier of positive symptoms and positive test date", () => {
-  const [startDate, endDate] = computeIsolationPeriod(
-    personWithPositiveSymptomsAndTest
-  );
-  expect(startDate).toStrictEqual(parseISO("2020-01-01"));
+  const endDate = computeIsolationPeriod(personWithPositiveSymptomsAndTest);
   expect(endDate).toStrictEqual(parseISO("2020-01-11"));
 });
 
 test("Person continues to isolate if symptoms have not improved in 24 hours", () => {
-  const [, endDate] = computeIsolationPeriod(personWithOngoingSymptoms);
+  const endDate = computeIsolationPeriod(personWithOngoingSymptoms);
   expect(endDate).not.toStrictEqual(parseISO("2020-01-11"));
 
-  const [, endDate2] = computeIsolationPeriod(
-    personWithPositiveSymptomsAndTest
-  );
+  const endDate2 = computeIsolationPeriod(personWithPositiveSymptomsAndTest);
   expect(endDate2).toStrictEqual(parseISO("2020-01-11"));
 });
 
@@ -125,7 +116,6 @@ test("Person exposed outside the household quarantines for 14 days", () => {
     [personWithOutsideExposure],
     []
   );
-  expect(calcluations[0].startDate).toStrictEqual(parseISO("2020-01-01"));
   expect(calcluations[0].endDate).toStrictEqual(parseISO("2020-01-15"));
 });
 
@@ -141,8 +131,6 @@ test("Given a household with a person with a positive test and a caretaker, the 
     [personWithPositiveTest, empty],
     [inHouseExposureEvent]
   );
-  expect(calcluations[0].startDate).toStrictEqual(parseISO("2020-01-01"));
-  expect(calcluations[1].startDate).toStrictEqual(parseISO("2020-01-01"));
   expect(calcluations[0].endDate).toStrictEqual(parseISO("2020-01-11"));
   expect(calcluations[1].endDate).toStrictEqual(parseISO("2020-01-25"));
 });
@@ -159,9 +147,7 @@ test("Given a household with a person with a positive test and an isolated famil
     [personWithPositiveTest, empty],
     [inHouseExposureEvent]
   );
-  expect(calcluations[0].startDate).toStrictEqual(parseISO("2020-01-01"));
   expect(calcluations[0].endDate).toStrictEqual(parseISO("2020-01-11"));
-  expect(calcluations[1].startDate).toStrictEqual(parseISO("2020-01-01"));
   expect(calcluations[1].endDate).toStrictEqual(parseISO("2020-01-19"));
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,6 @@ export interface InHouseExposureEvent {
 
 export interface CalculationResult {
   person: PersonData;
-  startDate: Date;
   endDate: Date;
   infected?: boolean;
 }


### PR DESCRIPTION
We start all events from 1/1/1970 (when epoch time started) on the calendar view.