### PR TITLE
Change guidance message to account for symptomatic people

### DIFF
--- a/src/Household.tsx
+++ b/src/Household.tsx
@@ -22,6 +22,25 @@ export default function Household(props: Props) {
   const editing = props.editingState.get();
   const members = props.membersState.get();
   const inHouseExposureEvents = props.inHouseExposureEventsState.get();
+
+  function guidanceMessage(result: CalculationResult) {
+    const date = format(result.endDate, "MM/dd/yyyy");
+    if (result.infected) {
+      if (result.person.noSymptomsFor24Hours) {
+        return `should isolate until ${date}.`;
+      } else {
+        return `should isolate until at least ${date} and 24 hours after symptoms improve.`;
+      }
+    } else {
+      if (result.peopleWithOngoingExposureWithSymptoms?.length) {
+        const names = result.peopleWithOngoingExposureWithSymptoms?.join(", ");
+        return `should quarantine until at least ${date} and 11 days after symptoms improve for ${names}.`;
+      } else {
+        return `should quarantine until ${date}.`;
+      }
+    }
+  }
+
   return (
     <>
       <div className="p-3">
@@ -76,12 +95,7 @@ export default function Household(props: Props) {
                       ></i>
                       {result.person.name + " "}
                     </span>{" "}
-                    should {result.infected ? "isolate" : "quarantine"}
-                    {" until "}
-                    {result.person.noSymptomsFor24Hours
-                      ? format(result.endDate, "MM/dd/yyyy")
-                      : " 24 hours after symptoms improve"}
-                    {"."}
+                    {guidanceMessage(result)}
                   </div>
                 );
               }

--- a/src/calculator.ts
+++ b/src/calculator.ts
@@ -57,10 +57,24 @@ export function computeHouseHoldQuarantinePeriod(
           outHouseExposureDate
         ])
       );
+      const peopleWithOngoingExposureWithSymptoms = flow(
+        map((event: InHouseExposureEvent) => {
+          if (event.ongoing) {
+            const personWithOngoingExposure = infected.find(
+              calculation => calculation.person.id === event.contagiousPerson
+            )?.person;
+            if (!personWithOngoingExposure?.noSymptomsFor24Hours) {
+              return personWithOngoingExposure?.name;
+            }
+          }
+        }),
+        compact
+      )(relevantInHouseExposureEvents);
       const fourteenDaysFromLastExposure = addDays(latestExposureDate, 14);
       return {
         person: person,
         endDate: fourteenDaysFromLastExposure,
+        peopleWithOngoingExposureWithSymptoms: peopleWithOngoingExposureWithSymptoms,
         infected: false
       };
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,7 @@ export interface InHouseExposureEvent {
 export interface CalculationResult {
   person: PersonData;
   endDate: Date;
+  peopleWithOngoingExposureWithSymptoms?: string[];
   infected?: boolean;
 }
 


### PR DESCRIPTION
There are now 4 patterns of messages.

Alice should isolate until 01/01/2020.
Alice should isolate until at least 01/01/2020 and 24 hours after symptoms improve.
Alice should quarantine until 01/01/2020.
Alice should quarantine until at least 01/01/2020 and 11 days after symptoms improve for Bob.