### PR TITLE
Update z-index for date picker

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -35,3 +35,7 @@
 div.react-datepicker-wrapper {
   display: block;
 }
+
+div.react-datepicker-popper {
+    z-index: 100;
+}


### PR DESCRIPTION
This ensures that the date picker always shows up "above" all other elements.