### PR TITLE
Change calculator in preparation for reason strings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { useState } from "@hookstate/core";
 import Household from "./Household";
 import Home from "./Home";
-import { CovidEventName, InHouseExposureEvent, PersonData } from "./types";
+import { CovidEventName, InHouseExposure, PersonData } from "./types";
 import { compact } from "lodash/fp";
 import { getRandomInt, isContagious } from "./util";
 import { BrowserRouter as Router, Switch, Route } from "react-router-dom";
@@ -17,7 +17,7 @@ export default function App() {
     return () => window.removeEventListener("resize", updateHeight);
   }, []);
   const members = useState([] as PersonData[]);
-  const inHouseExposureEvents = useState<InHouseExposureEvent[]>([]);
+  const inHouseExposureEvents = useState<InHouseExposure[]>([]);
   const id = useState(members.length + 1);
   const editingHouseholdState = useState(true);
   const editingPersonState = useState<number | undefined>(undefined);

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,12 +1,12 @@
 import React from "react";
 import GridView from "./GridView";
 import { Link } from "react-router-dom";
-import { InHouseExposureEvent, PersonData } from "./types";
+import { InHouseExposure, PersonData } from "./types";
 import { State } from "@hookstate/core/dist";
 
 interface Props {
   membersState: State<PersonData[]>;
-  inHouseExposureEventsState: State<InHouseExposureEvent[]>;
+  inHouseExposureEventsState: State<InHouseExposure[]>;
 }
 
 export default function Home(props: Props) {

--- a/src/Household.tsx
+++ b/src/Household.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { InHouseExposureEvent, PersonData } from "./types";
+import { InHouseExposure, PersonData } from "./types";
 import Person from "./Person";
 import { State } from "@hookstate/core";
 import { computeHouseHoldQuarantinePeriod } from "./calculator";
@@ -8,7 +8,7 @@ import { Link } from "react-router-dom";
 interface Props {
   addNewPerson: () => void;
   membersState: State<PersonData[]>;
-  inHouseExposureEventsState: State<InHouseExposureEvent[]>;
+  inHouseExposureEventsState: State<InHouseExposure[]>;
   editingHouseholdState: State<boolean>;
   editingPersonState: State<number | undefined>;
   height: State<number>;

--- a/src/InHouseExposureQuestion.tsx
+++ b/src/InHouseExposureQuestion.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { InHouseExposureEvent, PersonData } from "./types";
+import { InHouseExposure, PersonData } from "./types";
 import { State } from "@hookstate/core";
 import MultipleChoiceQuestion from "./MultipleChoiceQuestion";
 import DateQuestion from "./DateQuestion";
@@ -10,7 +10,7 @@ interface Props {
   index: number;
   person: PersonData;
   otherPerson: PersonData;
-  inHouseExposureEventState: State<InHouseExposureEvent>;
+  inHouseExposureEventState: State<InHouseExposure>;
 }
 
 export default function InHouseExposureQuestion(props: Props) {

--- a/src/InHouseExposureQuestions.tsx
+++ b/src/InHouseExposureQuestions.tsx
@@ -1,4 +1,4 @@
-import { InHouseExposureEvent, PersonData } from "./types";
+import { InHouseExposure, PersonData } from "./types";
 import InHouseExposureQuestion from "./InHouseExposureQuestion";
 import React from "react";
 import { State } from "@hookstate/core/dist";
@@ -6,7 +6,7 @@ import { State } from "@hookstate/core/dist";
 interface Props {
   person: PersonData;
   meaningfulInHouseExposures: PersonData[];
-  relevantInHouseExposureEventsState: State<InHouseExposureEvent>[];
+  relevantInHouseExposureEventsState: State<InHouseExposure>[];
 }
 
 export default function InHouseExposureQuestions(props: Props) {
@@ -14,7 +14,7 @@ export default function InHouseExposureQuestions(props: Props) {
     <>
       {props.meaningfulInHouseExposures.map((otherPerson, index) => {
         const inHouseExposureEventState = props.relevantInHouseExposureEventsState.find(
-          (eventState: State<InHouseExposureEvent>) => {
+          (eventState: State<InHouseExposure>) => {
             const event = eventState.get();
             return (
               event.quarantinedPerson === otherPerson.id ||

--- a/src/calculator.test.ts
+++ b/src/calculator.test.ts
@@ -85,7 +85,7 @@ const personWithOutsideExposure: PersonData = {
 
 test("Empty", () => {
   const endDate = computeIsolationPeriod(empty);
-  expect(isValid(endDate)).toBe(false);
+  expect(endDate).toBe(undefined);
 });
 
 test("Person with positive symptoms isolates for 10 days", () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export type CovidEvents = {
   [key in CovidEventName]: string;
 };
 
-export interface InHouseExposureEvent {
+export interface InHouseExposure {
   contagiousPerson: number;
   quarantinedPerson: number;
   exposed: boolean;
@@ -25,11 +25,17 @@ export interface InHouseExposureEvent {
   date: string;
 }
 
-export interface CalculationResult {
+export interface Exposure {
+  date: Date;
+  infectionSource?: PersonData;
+}
+
+export interface Guidance {
   person: PersonData;
-  endDate: Date;
+  infected: boolean;
+  endDate?: Date;
+  infectionSource?: PersonData;
   peopleWithOngoingExposureWithSymptoms?: string[];
-  infected?: boolean;
 }
 
 export const colors = [


### PR DESCRIPTION
NFC from users perspective (besides change that fixes https://github.com/codeforpdx/covid-calendar/issues/83).

We remove the use of isValid from date-fns and instead rely on undefined as the sole source of a none-type for consistency. We now pass through information about who is the infection source in the Guidance object.