### PR TITLE
Fix "TypeError: infectedGuidance is undefined"

### DIFF
--- a/src/Person.tsx
+++ b/src/Person.tsx
@@ -156,7 +156,7 @@ export default function Person(props: Props) {
   }
 
   function setContagiousState(contagious: boolean) {
-    relevantInHouseExposureEventsState.map(e => e.set(none)); // Remove all current exposures
+    relevantInHouseExposureEventsState.reverse().map(e => e.set(none)); // Remove all current exposures
     const newExposureEvents = members.map((otherPerson: PersonData) => {
       const otherContagious = isContagious(otherPerson);
       if (person !== otherPerson && contagious !== otherContagious) {
@@ -180,7 +180,7 @@ export default function Person(props: Props) {
   );
 
   function removeFromMembers() {
-    relevantInHouseExposureEventsState.map(e => e.set(none)); // Remove all current exposures
+    relevantInHouseExposureEventsState.reverse().map(e => e.set(none)); // Remove all current exposures
     props.personState.set(none);
   }
 


### PR DESCRIPTION
This is a workaround. For some reason `relevantInHouseExposureEventsState.map(e => e.set(none));` does not remove all relevant in house exposure events state. However, if I remove it from the reverse direction, it works fine. I will have to dig deeper in the hookstate to figure out why.